### PR TITLE
Fix: ttlSecondsAfterFinished not taking effect.

### DIFF
--- a/pkg/controller.v1/pytorch/controller.go
+++ b/pkg/controller.v1/pytorch/controller.go
@@ -526,7 +526,9 @@ func (pc *PyTorchController) satisfiedExpectations(job *pyv1.PyTorchJob) bool {
 		satisfied = satisfied || pc.Expectations.SatisfiedExpectations(expectationServicesKey)
 	}
 
-	if util.CheckJobCompleted(job.Status.Conditions) && job.DeletionTimestamp == nil && job.Annotations[PytorchCleanPodStatusLabel] == PytorchCleanStatusDone {
+	if util.CheckJobCompleted(job.Status.Conditions) && job.DeletionTimestamp == nil &&
+		job.Annotations[PytorchCleanPodStatusLabel] == PytorchCleanStatusDone &&
+		job.Spec.TTLSecondsAfterFinished == nil {
 		satisfied = false
 	}
 


### PR DESCRIPTION
if pytorchjob completed, it would not reconcile again, ttlSecondsAfterFinished won't take effect even if configured.